### PR TITLE
test: fix oracle observation tests

### DIFF
--- a/src/interfaces/ITruncGeoOracleMulti.sol
+++ b/src/interfaces/ITruncGeoOracleMulti.sol
@@ -41,7 +41,7 @@ interface ITruncGeoOracleMulti {
     function getLastObservation(PoolId poolId)
         external
         view
-        returns (uint32 timestamp, int24 tick, int48 tickCumulative, uint144 secondsPerLiquidityCumulativeX128);
+        returns (uint32 timestamp, int24 tick, int56 tickCumulative, uint160 secondsPerLiquidityCumulativeX128);
 
     /**
      * @notice Updates the maximum tick movement for a pool.
@@ -57,10 +57,15 @@ interface ITruncGeoOracleMulti {
      * @return tickCumulatives The tick cumulative values.
      * @return secondsPerLiquidityCumulativeX128s The seconds per liquidity cumulative values.
      */
+    /// @notice Returns cumulative tick and seconds-per-liquidity for each `secondsAgo`.
+    /// @dev Typed to mirror Uniswap V3 so off-the-shelf TWAP helpers "just work".
     function observe(bytes calldata key, uint32[] calldata secondsAgos)
         external
         view
-        returns (int48[] memory tickCumulatives, uint144[] memory secondsPerLiquidityCumulativeX128s);
+        returns (
+            int56[]  memory tickCumulatives,
+            uint160[] memory secondsPerLiquidityCumulativeX128s
+        );
 
     /**
      * @notice Increases the cardinality of the oracle observation array


### PR DESCRIPTION
- Fix array out-of-bounds in TruncGeoOracleMultiTest - Update TruncatedOracle tests to reflect upstream capping - Improve test comments and assertions - Move tick capping upstream from TruncatedOracle library - Update cumulative value types to prevent overflow (int48 → int56, uint144 → uint160) - Add safe casting helpers and improve error handling