### PR TITLE
ci: add a Uniswap v4 hook risk check

### DIFF
--- a/.github/workflows/hookguard.yml
+++ b/.github/workflows/hookguard.yml
@@ -1,0 +1,23 @@
+name: hookguard
+
+# Checks the hook for known Uniswap v4 footguns on every change.
+# Heuristic pattern matching, not an audit. Annotates only, never blocks.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: chaosxcode/hookguard@v1
+        with:
+          paths: src
+          fail-on: never


### PR DESCRIPTION
Adds one workflow that runs [HookGuard](https://github.com/chaosxcode/hookguard) on every pull request.

**What it does.** It looks for a specific set of Uniswap v4 mistakes and comments on the exact line when it finds one — callbacks any address can call, hooks keeping per-pool state without checking which pool is calling, dynamic fees with no ceiling. Every rule traces to published guidance (Trail of Bits' v4 hooks paper, Uniswap's security framework) or to the Bunni v2 and Cork post-mortems.

**On this repo specifically.** It picks up `Spot` in this repo and flags:

| Contract | Severity | Rule | Line |
|---|---|---|---:|
| `Spot` | MEDIUM | `PERMISSIONLESS_ATTACHMENT` | 54 |

None of that is necessarily wrong — MEDIUM means *worth confirming it's deliberate*, not *broken*. The point is it'll tell you if that changes.

**It can't block you.** `fail-on: never` means annotations only. Drop that line if you'd rather it gate on serious findings.

**Straight about the limits.** Heuristic pattern matching, not an audit. It reads permissions and source patterns, not what your hook actually does. A flag means *worth a look*, never *broken*; silence means nothing matched at this level, never *safe*.

I tested it against 272 real deployed hooks and [wrote up the five ways it was wrong](https://github.com/chaosxcode/hookguard/blob/master/docs/precision.md), plus what I changed. Just over half of real hooks come back clean.

Close it without a second thought if you'd rather not take on a dependency.